### PR TITLE
Return early if provided address is invalid

### DIFF
--- a/faucet.js
+++ b/faucet.js
@@ -59,6 +59,7 @@ async function run() {
         if(!req.query.address || req.query.address.length != 63) {
             res.status(400);
             res.send({'message': 'Invalid address provided!'})
+            return;
         }
         
         const node_res = await synced.send(req.query.address, amount);


### PR DESCRIPTION
If an incorrect address is provided, the api method still tries to make the send call. This PR fixes the issue by making an early return