### PR TITLE
Append backend URL to fetch params & extract JSON from response correctly

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -6,8 +6,7 @@
     let success = false;
     let data = null;
     const explorer = 'https://tangle-explorer.dag.sh/chrysalis/';
-    const backendUrl = 'http://localhost:3000';
-
+	
     function validate(event) {
         done = false;
         if ((address.length == 63 && address[3] == '1') || address.length == 64 && address[4] == '1' ) {
@@ -23,7 +22,7 @@
         }
         waiting = true;
 
-        const res = await fetch(`${backendUrl}/api?address=${address}`);
+        const res = await fetch(`/api?address=${address}`);
         data = await res.json();
 
         success = (res.status == 200);


### PR DESCRIPTION
As backend URL is different from frontend URL, it needs to be explicitly defined during network call through fetch.

This PR also extracts the JSON correctly from the response object received from server.